### PR TITLE
Add support for cross-compiling the firmware image

### DIFF
--- a/pkgs/atf/default.nix
+++ b/pkgs/atf/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, buildPackages
 , fetchFromGitHub
 , tianocore
 , rcw
@@ -11,6 +12,7 @@
 assert lib.elem bootMode [ "sd" "spi" ];
 let
   atfBoot = if bootMode == "sd" then "sd" else "flexspi_nor";
+  isCross = stdenv.buildPlatform != stdenv.hostPlatform;
 in
 stdenv.mkDerivation rec {
   pname = "atf";
@@ -25,7 +27,8 @@ stdenv.mkDerivation rec {
 
   enableParallelBuilding = true;
 
-  buildInputs = [ openssl ];
+  depsBuildBuild = [ buildPackages.stdenv.cc ];
+  nativeBuildInputs = [ openssl ];
 
   makeFlags = [
     "PLAT=lx2160acex7"
@@ -35,6 +38,7 @@ stdenv.mkDerivation rec {
     "GENERATE_COT=0"
     "BOOT_MODE=${atfBoot}"
     "SECURE_BOOT=false"
+  ] ++ lib.optional isCross "CROSS_COMPILE=${stdenv.cc.targetPrefix}" ++ [
     "all"
     "fip"
     "pbl"

--- a/pkgs/rcw/default.nix
+++ b/pkgs/rcw/default.nix
@@ -1,5 +1,6 @@
 { stdenv
 , lib
+, buildPackages
 , fetchFromGitHub
 , python3
 , gettext
@@ -22,6 +23,10 @@ stdenv.mkDerivation rec {
   };
 
   nativeBuildInputs = [ python3 gettext ];
+
+  postPatch = ''
+    sed -i 's@gcc@${buildPackages.stdenv.cc}/bin/gcc@' Makefile.inc rcw.py
+  '';
 
   preBuild = ''
     cd lx2160acex7

--- a/pkgs/tianocore/default.nix
+++ b/pkgs/tianocore/default.nix
@@ -15,7 +15,7 @@ let
 in
 edk2.mkDerivation "${edk2-platforms}/Platform/SolidRun/LX2160aCex7/LX2160aCex7.dsc" {
   name = "tianocore-honeycomb-lx2k";
-  buildInputs = [ utillinux nasm iasl dtc ];
+  nativeBuildInputs = [ utillinux nasm iasl dtc ];
   hardeningDisable = [ "format" "stackprotector" "pic" "fortify" ];
   preBuild = ''
     export PACKAGES_PATH=${edk2}:${edk2-platforms}:${edk2-non-osi}


### PR DESCRIPTION
Minor fixes in the firmware derivations in order to support build on an `x86_64` host.

Tested with:
```
$ nix-build --arg system \"x86_64-linux\" -A lx2k.uefi -o uefi.img
```

Builds properly, though I haven't been able to test yet that it fully works (I'm debugging RAM issues in ATF right now... so at least ATF is properly built).