### PR TITLE
fix building with Nixos 21.11

### DIFF
--- a/pkgs/edk2/default.nix
+++ b/pkgs/edk2/default.nix
@@ -1,4 +1,4 @@
-{ stdenv, lib, buildPackages, fetchFromGitHub, libuuid, python3, bc }:
+{ stdenv, lib, buildPackages, fetchFromGitHub, libuuid, python38, bc }:
 let
   edk2 = stdenv.mkDerivation {
     pname = "edk2-solidrun";
@@ -12,7 +12,7 @@ let
     };
 
     depsBuildBuild = [ buildPackages.stdenv.cc ];
-    nativeBuildInputs = [ libuuid python3 ];
+    nativeBuildInputs = [ libuuid python38 ];
 
     postPatch = "patchShebangs BaseTools/BinWrappers";
 
@@ -35,7 +35,7 @@ let
       mkDerivation = projectDscPath: attrs: stdenv.mkDerivation ({
         inherit (edk2) src;
 
-        nativeBuildInputs = [ bc python3 ] ++ attrs.nativeBuildInputs or [ ];
+        nativeBuildInputs = [ bc python38 ] ++ attrs.nativeBuildInputs or [ ];
 
         prePatch = ''
           rm -rf BaseTools

--- a/pkgs/tianocore/default.nix
+++ b/pkgs/tianocore/default.nix
@@ -1,4 +1,4 @@
-{ fetchFromGitHub, edk2, utillinux, nasm, iasl, dtc }:
+{ fetchFromGitHub, edk2, utillinux, nasm, acpica-tools, dtc }:
 let
   edk2-platforms = fetchFromGitHub {
     owner = "SolidRun";
@@ -15,7 +15,7 @@ let
 in
 edk2.mkDerivation "${edk2-platforms}/Platform/SolidRun/LX2160aCex7/LX2160aCex7.dsc" {
   name = "tianocore-honeycomb-lx2k";
-  nativeBuildInputs = [ utillinux nasm iasl dtc ];
+  nativeBuildInputs = [ utillinux nasm acpica-tools dtc ];
   hardeningDisable = [ "format" "stackprotector" "pic" "fortify" ];
   preBuild = ''
     export PACKAGES_PATH=${edk2}:${edk2-platforms}:${edk2-non-osi}


### PR DESCRIPTION
Hi, thanks for your (and others') work in this repo. I've successfully used it to build EDK for my Honeycomb.

Not sure if you're taking PRs here. This is just the minimal changes needed to keep things working on top of Nixos 21.11.

I also have patches to update the firmware to LSDK 21.08, and fix broken `SERDES=4_5_2` config in Tianocore, which I can send as followup PRs if you're interested.